### PR TITLE
Add support for eCash RTT

### DIFF
--- a/src/bitcoin.c
+++ b/src/bitcoin.c
@@ -212,13 +212,16 @@ bool gen_gbtbase(connsock_t *cs, gbtbase_t *gbt)
 
 	gbt->flags = strdup(flags);
 
+	gbt->rtt_diff = gbt->diff;
+
 	// XEC only.
 	if (cs->ckp->ecash) {
-		json_t *coinbasetxn, *minerfund;
-		const char *minerfund_addr;
+		json_t *coinbasetxn, *minerfund, *rtt;
+		const char *minerfund_addr, *rtt_bits_hex;
 		uint64_t minerfund_amount;
 		bool script, segwit;
 		char *minerfundtxn;
+		char rtt_bits[4];
 
 		coinbasetxn = json_object_get(res_val, "coinbasetxn");
 
@@ -249,6 +252,12 @@ bool gen_gbtbase(connsock_t *cs, gbtbase_t *gbt)
 			gbt->stakingrewards_amount = json_integer_value(json_object_get(stakingrewards, "minimumvalue"));
 			gbt->stakingrewards_txnlen = strlen(stakingrewards_script_hex) / 2;
 			hex2bin(gbt->stakingrewards_txn, stakingrewards_script_hex, gbt->stakingrewards_txnlen);
+		}
+
+		rtt = json_object_get(res_val, "rtt");
+		rtt_bits_hex = json_string_value(json_object_get(rtt, "nexttarget"));
+		if (rtt_bits_hex && hex2bin(rtt_bits, rtt_bits_hex, 4)) {
+			gbt->rtt_diff = diff_from_nbits(rtt_bits);
 		}
 	}
 

--- a/src/libckpool.c
+++ b/src/libckpool.c
@@ -2449,7 +2449,7 @@ double diff_from_betarget(uchar *target)
 
 /* Return the network difficulty from the block header which is in packed form,
  * as a double. */
-double diff_from_nbits(char *nbits)
+double diff_from_nbits(const char *nbits)
 {
 	uint8_t shift = nbits[0];
 	uchar target[32] = {};

--- a/src/libckpool.h
+++ b/src/libckpool.h
@@ -623,7 +623,7 @@ double le256todouble(const uchar *target);
 double be256todouble(const uchar *target);
 double diff_from_target(uchar *target);
 double diff_from_betarget(uchar *target);
-double diff_from_nbits(char *nbits);
+double diff_from_nbits(const char *nbits);
 void target_from_diff(uchar *target, double diff);
 
 void gen_hash(uchar *data, uchar *hash, int len);

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -1074,12 +1074,21 @@ static void add_base(ckpool_t *ckp, sdata_t *sdata, workbase_t *wb, bool *new_bl
 	ts_realtime(&wb->gentime);
 	/* Stats network_diff is not protected by lock but is not a critical
 	 * value */
-	wb->network_diff = diff_from_nbits(wb->headerbin + 72);
+	// XEC only.
+	if (ckp->ecash) {
+		wb->network_diff = wb->rtt_diff;
+	} else {
+		wb->network_diff = diff_from_nbits(wb->headerbin + 72);
+	}
 	if (wb->network_diff < 1)
 		wb->network_diff = 1;
 	stats->network_diff = wb->network_diff;
-	if (stats->network_diff != old_diff)
-		LOGWARNING("Network diff set to %.1f", stats->network_diff);
+	if (stats->network_diff != old_diff) {
+		LOGWARNING("Network diff updated to %.1f", stats->network_diff);
+	} else {
+		LOGWARNING("Network diff constant: %.1f", stats->network_diff);
+	}
+
 	len = strlen(ckp->logdir) + 8 + 1 + 16 + 1;
 	wb->logdir = ckzalloc(len);
 

--- a/src/stratifier.h
+++ b/src/stratifier.h
@@ -83,6 +83,8 @@ struct genwork {
 	char stakingrewards_txn[256]; // staking rewards txn
 	int stakingrewards_txnlen; // length of above
 	uint64_t stakingrewards_amount; // staking rewards amount
+	
+	double rtt_diff; // real time difficulty
 
 	/* Cached header binary */
 	char headerbin[112];


### PR DESCRIPTION
This adds support for the `rtt` field in the block template introduced in https://reviews.bitcoinabc.org/D16730.
If the field is absent there is no change in behavior. If it is present, the `nexttarget` field is used as the network diff instead of the regular target.