### PR TITLE
Fix RTT network_diff gating valid blocks, and a broken format string in decode_cashaddr

### DIFF
--- a/src/libckpool.c
+++ b/src/libckpool.c
@@ -1868,7 +1868,7 @@ bool decode_cashaddr(const char *addr, char *prefix, int prefix_len, bool *scrip
 			// The separator cannot be the first character, cannot have number
 			// and there must not be 2 separators.
 			if (hasNumber || i == 0 || prefix_char_count != 0) {
-				LOGERR("Invalid prefix in cash address %s\n, addr");
+				LOGERR("Invalid prefix in cash address %s\n", addr);
 				return false;
 			}
 

--- a/src/stratifier.c
+++ b/src/stratifier.c
@@ -1074,12 +1074,14 @@ static void add_base(ckpool_t *ckp, sdata_t *sdata, workbase_t *wb, bool *new_bl
 	ts_realtime(&wb->gentime);
 	/* Stats network_diff is not protected by lock but is not a critical
 	 * value */
-	// XEC only.
-	if (ckp->ecash) {
-		wb->network_diff = wb->rtt_diff;
-	} else {
-		wb->network_diff = diff_from_nbits(wb->headerbin + 72);
-	}
+	/* Use the current job's actual header-derived target for network_diff,
+	 * on every chain including eCash. This value gates block detection in
+	 * test_blocksolve() and must match what the node itself checks on
+	 * submission. wb->rtt_diff (eCash "rtt.nexttarget") is a forward-looking
+	 * estimate that is transiently wrong by orders of magnitude right after
+	 * a block change, which caused genuinely valid blocks found in that
+	 * window to never be submitted. See issue Bitcoin-ABC/ecash-ckpool-solo#10. */
+	wb->network_diff = diff_from_nbits(wb->headerbin + 72);
 	if (wb->network_diff < 1)
 		wb->network_diff = 1;
 	stats->network_diff = wb->network_diff;


### PR DESCRIPTION
Fixes #10.

## 1. `network_diff` transiently wrong by orders of magnitude after every block change

`add_base()` set `network_diff` from `wb->rtt_diff` (eCash `rtt.nexttarget`) on eCash, which is transiently wrong by many orders of magnitude for several minutes after every block change before settling back to the correct value (observed in production: spiked to `1.4×10²⁰` immediately after a block, took ~5-6 minutes to decay back to the real ~7.3G).

`test_blocksolve()` gates block submission on `diff < network_diff`. While `network_diff` is inflated, no realistic share can pass this check, so a genuinely valid block found in that window is silently dropped and never submitted to the node. Verified in production logs (see linked issue for the full trace).

Fix: use the same header-derived target for eCash as every other supported chain. This is exactly what the node itself checks on block submission, and removes the transient-estimate code path entirely for this critical gate.

## 2. Broken format string in `decode_cashaddr()`

Found via `-Wformat` while rebuilding for fix #1:
```
libckpool.c:1871:40: warning: format '%s' expects a matching 'char *' argument [-Wformat=]
LOGERR("Invalid prefix in cash address %s\n, addr");
```
The `%s` conversion and its argument were both inside the string literal instead of `addr` being passed as a separate vararg — undefined behavior (reads an unsupplied vararg) whenever an address with a misplaced colon is decoded.

## Testing

Deployed both fixes to a production solo-mining ckpool instance (4 active Bitaxe/NerdQAxe miners on eCash). Verified via a captured live stratum job that the coinbase output structure (miner reward / minerfund / stakingrewards) still matches `getblocktemplate` exactly. Currently monitoring for the next real block change to confirm `network_diff` no longer spikes.